### PR TITLE
Fix no_mangle attribute and cleanup gitignore

### DIFF
--- a/blog_os/.gitignore
+++ b/blog_os/.gitignore
@@ -12,4 +12,3 @@ Cargo.lock
 .idea/
 .vscode/
 .DS_Store
-EOF

--- a/blog_os/src/main.rs
+++ b/blog_os/src/main.rs
@@ -7,7 +7,7 @@
 use blog_os::println;
 use core::panic::PanicInfo;
 
-#[unsafe(no_mangle)]
+#[no_mangle]
 pub extern "C" fn _start() -> ! {
     println!("Hello World{}", "!");
 

--- a/blog_os/tests/basic_boot.rs
+++ b/blog_os/tests/basic_boot.rs
@@ -7,7 +7,7 @@
 use blog_os::println;
 use core::panic::PanicInfo;
 
-#[unsafe(no_mangle)] // don't mangle the name of this function
+#[no_mangle] // don't mangle the name of this function
 pub extern "C" fn _start() -> ! {
     test_main();
 

--- a/blog_os/tests/should_panic.rs
+++ b/blog_os/tests/should_panic.rs
@@ -4,7 +4,7 @@
 use core::panic::PanicInfo;
 use blog_os::{exit_qemu, serial_print, serial_println, QemuExitCode};
 
-#[unsafe(no_mangle)]
+#[no_mangle]
 pub extern "C" fn _start() -> ! {
     should_fail();
     serial_println!("[test did not panic]");


### PR DESCRIPTION
## Summary
- fix invalid `#[unsafe(no_mangle)]` attribute in the kernel entry point and tests
- remove stray `EOF` line in `.gitignore`

## Testing
- `cargo test` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_b_6840aee82d648323ba9104229aca3c73