### PR TITLE
Activate allocator and demo FAT32 helper calls

### DIFF
--- a/blog_os/Cargo.toml
+++ b/blog_os/Cargo.toml
@@ -12,6 +12,16 @@ name = "oom"
 path = "tests/oom.rs"
 harness = false
 
+[[test]]
+name = "basic_boot"
+path = "tests/basic_boot.rs"
+harness = false
+
+[[test]]
+name = "fat32"
+path = "tests/fat32.rs"
+harness = false
+
 [dependencies]
 bootloader   = "0.9"
 volatile     = "0.2.6"

--- a/blog_os/src/allocator.rs
+++ b/blog_os/src/allocator.rs
@@ -100,17 +100,17 @@ impl Slab {
 ///
 /// Implémente le trait `GlobalAlloc` pour prendre en charge les allocations
 /// et libérations via la macro `#[global_allocator]`.
-pub struct SlabAllocator {
+pub struct SimpleAllocator {
     slabs: [Mutex<Slab>; N_SLABS],
 }
 
-unsafe impl Sync for SlabAllocator {}
-unsafe impl Send for SlabAllocator {}
+unsafe impl Sync for SimpleAllocator {}
+unsafe impl Send for SimpleAllocator {}
 
-impl SlabAllocator {
+impl SimpleAllocator {
     /// Construit un allocateur avec tous les slabs initialement non configurés.
     pub const fn new() -> Self {
-        SlabAllocator {
+        SimpleAllocator {
             slabs: [
                 Mutex::new(Slab::uninit(SLAB_SIZES[0])),
                 Mutex::new(Slab::uninit(SLAB_SIZES[1])),
@@ -121,12 +121,7 @@ impl SlabAllocator {
     }
 }
 
-/// Désigne `ALLOCATOR` comme allocateur global quand la feature `alloc` est active.
-#[cfg(feature = "alloc")]
-#[global_allocator]
-static ALLOCATOR: SlabAllocator = SlabAllocator::new();
-
-unsafe impl GlobalAlloc for SlabAllocator {
+unsafe impl GlobalAlloc for SimpleAllocator {
     /// Alloue un bloc de mémoire correspondant à `layout`.
     ///
     /// # Safety

--- a/blog_os/src/fat32.rs
+++ b/blog_os/src/fat32.rs
@@ -3,6 +3,14 @@ pub trait BlockDevice {
     fn write_sector(&mut self, lba: u32, buf: &[u8; 512]);
 }
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+#[cfg(feature = "alloc")]
+use alloc::{string::String, vec::Vec};
+#[cfg(feature = "alloc")]
+use alloc::{format, vec};
+
 #[derive(Debug, Clone, Copy)]
 pub struct BootSector {
     pub bytes_per_sector: u16,
@@ -11,6 +19,27 @@ pub struct BootSector {
     pub fats: u8,
     pub sectors_per_fat: u32,
     pub root_cluster: u32,
+}
+
+#[cfg_attr(feature = "alloc", derive(Debug, Clone))]
+pub struct DirectoryEntry {
+    pub name: [u8; 11],
+    pub attr: u8,
+    pub first_cluster: u32,
+    pub size: u32,
+}
+
+#[cfg(feature = "alloc")]
+impl DirectoryEntry {
+    pub fn filename(&self) -> String {
+        let name = core::str::from_utf8(&self.name[..8]).unwrap().trim_end();
+        let ext = core::str::from_utf8(&self.name[8..]).unwrap().trim_end();
+        if ext.is_empty() {
+            String::from(name)
+        } else {
+            format!("{}.{}", name, ext)
+        }
+    }
 }
 
 impl BootSector {
@@ -42,6 +71,100 @@ impl<D: BlockDevice> Fat32<D> {
     pub fn boot_sector(&self) -> &BootSector {
         &self.boot_sector
     }
+
+    /// Returns the size in bytes of a cluster.
+    pub fn cluster_size(&self) -> usize {
+        self.boot_sector.bytes_per_sector as usize
+            * self.boot_sector.sectors_per_cluster as usize
+    }
+
+    /// The first sector that contains data clusters.
+    pub fn first_data_sector(&self) -> u32 {
+        self.boot_sector.reserved_sectors as u32
+            + self.boot_sector.fats as u32 * self.boot_sector.sectors_per_fat
+    }
+
+    /// Converts a cluster number to a logical block address.
+    pub fn cluster_to_lba(&self, cluster: u32) -> u32 {
+        self.first_data_sector() + (cluster - 2) * self.boot_sector.sectors_per_cluster as u32
+    }
+
+    /// Reads the raw FAT entry for `cluster`.
+    pub fn read_fat_entry(&mut self, cluster: u32) -> u32 {
+        let fat_start = self.boot_sector.reserved_sectors as u32;
+        let offset = cluster * 4;
+        let sector = fat_start + (offset / 512);
+        let idx = (offset % 512) as usize;
+        let mut buf = [0u8; 512];
+        self.device.read_sector(sector, &mut buf);
+        let entry = u32::from_le_bytes([
+            buf[idx],
+            buf[idx + 1],
+            buf[idx + 2],
+            buf[idx + 3],
+        ]);
+        entry & 0x0FFF_FFFF
+    }
+
+    /// Reads a full cluster into `buf`.
+    pub fn read_cluster(&mut self, cluster: u32, buf: &mut [u8]) {
+        let lba = self.cluster_to_lba(cluster);
+        let mut tmp = [0u8; 512];
+        self.device.read_sector(lba, &mut tmp);
+        buf[..512].copy_from_slice(&tmp);
+    }
+
+    #[cfg(feature = "alloc")]
+    fn read_cluster_chain(&mut self, start: u32) -> Result<Vec<u8>, ()> {
+        if start < 2 {
+            panic!("invalid cluster {}", start);
+        }
+        let cluster_size = self.cluster_size();
+        let mut current = start;
+        let mut data = Vec::new();
+        loop {
+            let mut buf = vec![0u8; cluster_size];
+            self.read_cluster(current, &mut buf);
+            data.extend_from_slice(&buf);
+            let next = self.read_fat_entry(current);
+            if next >= 0x0FFF_FFF8 {
+                break;
+            }
+            if next < 2 {
+                panic!("invalid FAT entry {}", next);
+            }
+            current = next;
+        }
+        Ok(data)
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn read_root_directory(&mut self) -> Result<Vec<DirectoryEntry>, ()> {
+        let data = self.read_cluster_chain(self.boot_sector.root_cluster)?;
+        let mut entries = Vec::new();
+        for chunk in data.chunks(32) {
+            if chunk[0] == 0x00 { break; }
+            if chunk[0] == 0xE5 { continue; }
+            let mut name = [0u8; 11];
+            name.copy_from_slice(&chunk[0..11]);
+            let attr = chunk[11];
+            let first_cluster =
+                ((u16::from_le_bytes([chunk[20], chunk[21]]) as u32) << 16)
+                | u16::from_le_bytes([chunk[26], chunk[27]]) as u32;
+            let size = u32::from_le_bytes([
+                chunk[28], chunk[29], chunk[30], chunk[31]
+            ]);
+            entries.push(DirectoryEntry { name, attr, first_cluster, size });
+        }
+        Ok(entries)
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn open_file(&mut self, entry: &DirectoryEntry) -> Result<Vec<u8>, ()> {
+        let mut data = self.read_cluster_chain(entry.first_cluster)?;
+        data.truncate(entry.size as usize);
+        Ok(data)
+    }
 }
 
 pub struct MemoryDisk {
@@ -51,13 +174,37 @@ pub struct MemoryDisk {
 impl MemoryDisk {
     pub fn new() -> Self {
         let mut data = [0u8; 4096];
-        // minimal boot sector setup
+        // boot sector
         data[11..13].copy_from_slice(&512u16.to_le_bytes());
         data[13] = 1; // sectors per cluster
-        data[14..16].copy_from_slice(&1u16.to_le_bytes()); // reserved
-        data[16] = 2; // fats
-        data[36..40].copy_from_slice(&1u32.to_le_bytes()); // sectors per fat
-        data[44..48].copy_from_slice(&2u32.to_le_bytes()); // root cluster
+        data[14..16].copy_from_slice(&1u16.to_le_bytes()); // reserved sectors
+        data[16] = 2; // number of FATs
+        data[36..40].copy_from_slice(&1u32.to_le_bytes()); // sectors per FAT
+        data[44..48].copy_from_slice(&2u32.to_le_bytes()); // root cluster = 2
+
+        // FAT table (sector 1 and 2)
+        let mut fat_sector = [0u8; 512];
+        fat_sector[0..4].copy_from_slice(&0x0FFFFFF8u32.to_le_bytes()); // entry 0
+        fat_sector[4..8].copy_from_slice(&0xFFFFFFFFu32.to_le_bytes()); // entry 1
+        fat_sector[8..12].copy_from_slice(&0x0FFFFFFFu32.to_le_bytes()); // cluster2 end
+        fat_sector[12..16].copy_from_slice(&0x0FFFFFFFu32.to_le_bytes()); // cluster3 end
+        data[512..1024].copy_from_slice(&fat_sector); // FAT1
+        data[1024..1536].copy_from_slice(&fat_sector); // FAT2
+
+        // root directory (cluster2 -> sector 3)
+        let start = 1536; // 3*512
+        let name: [u8; 11] = *b"HELLO   TXT";
+        let mut dir = [0u8; 32];
+        dir[0..11].copy_from_slice(&name);
+        dir[11] = 0x20; // file attr
+        dir[26..28].copy_from_slice(&3u16.to_le_bytes()); // first cluster low
+        dir[28..32].copy_from_slice(&5u32.to_le_bytes()); // file size
+        data[start..start + 32].copy_from_slice(&dir);
+
+        // file data cluster3 (sector 4)
+        let data_start = 2048; // 4*512
+        data[data_start..data_start + 5].copy_from_slice(b"Hello");
+
         Self { data }
     }
 }

--- a/blog_os/src/lib.rs
+++ b/blog_os/src/lib.rs
@@ -36,6 +36,10 @@ pub mod vga_buffer;
 pub mod allocator;
 pub mod fat32;
 
+#[cfg(feature = "alloc")]
+#[global_allocator]
+static ALLOCATOR: allocator::SimpleAllocator = allocator::SimpleAllocator::new();
+
 /// Trait étendant les tests pour permettre l'affichage de leur nom.
 pub trait Testable {
     fn run(&self);

--- a/blog_os/tests/basic_boot.rs
+++ b/blog_os/tests/basic_boot.rs
@@ -23,3 +23,10 @@ fn panic(info: &PanicInfo) -> ! {
 fn test_println() {
     println!("test_println output");
 }
+
+#[cfg(feature = "alloc")]
+#[test_case]
+fn basic_allocator_test() {
+    let value = Box::new(123_u32);
+    assert_eq!(*value, 123);
+}

--- a/blog_os/tests/fat32.rs
+++ b/blog_os/tests/fat32.rs
@@ -1,0 +1,41 @@
+#![no_std]
+#![no_main]
+#![feature(custom_test_frameworks)]
+#![test_runner(blog_os::test_runner)]
+#![reexport_test_harness_main = "test_main"]
+
+extern crate alloc;
+
+use blog_os::fat32::{Fat32, MemoryDisk};
+use blog_os::{test_panic_handler};
+use alloc::vec::Vec;
+use core::panic::PanicInfo;
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    test_main();
+    loop {}
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+#[test_case]
+fn read_root_dir_test() {
+    let disk = MemoryDisk::new();
+    let mut fs = Fat32::new(disk).unwrap();
+    let entries = fs.read_root_directory().unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].filename(), "HELLO.TXT");
+}
+
+#[test_case]
+fn read_file_test() {
+    let disk = MemoryDisk::new();
+    let mut fs = Fat32::new(disk).unwrap();
+    let entries = fs.read_root_directory().unwrap();
+    let data = fs.open_file(&entries[0]).unwrap();
+    assert_eq!(core::str::from_utf8(&data).unwrap(), "Hello");
+}

--- a/blog_os/tests/should_panic.rs
+++ b/blog_os/tests/should_panic.rs
@@ -2,19 +2,18 @@
 #![no_main]
 
 use core::panic::PanicInfo;
-use blog_os::{exit_qemu, serial_print, serial_println, QemuExitCode};
+use blog_os::{exit_qemu, serial_println, QemuExitCode};
+use blog_os::fat32::{Fat32, MemoryDisk, DirectoryEntry};
 
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
-    should_fail();
+    serial_println!("should_panic::invalid_cluster...");
+    let disk = MemoryDisk::new();
+    let mut fs = Fat32::new(disk).expect("fs");
+    let entry = DirectoryEntry { name: *b"BADFILEBIN  ", attr: 0x20, first_cluster: 99, size: 1 };
+    let _ = fs.open_file(&entry);
     serial_println!("[test did not panic]");
     exit_qemu(QemuExitCode::Failed);
-    
-}
-
-fn should_fail() {
-    serial_print!("should_panic::should_fail...\t");
-    assert_eq!(0, 1);
 }
 
 #[panic_handler]


### PR DESCRIPTION
## Summary
- use `SimpleAllocator` as the global allocator
- expose low level FAT32 helper methods
- demo FAT32 helpers from `_start`

## Testing
- `cargo +nightly test --no-run --target x86_64-blog_os.json --features alloc,oom_integration` *(fails: could not download nightly toolchain)*

------
https://chatgpt.com/codex/tasks/task_b_6841e3ff6fcc83239b84699e8bedb043