### PR TITLE
Fix test entry for panic case

### DIFF
--- a/blog_os/tests/should_panic.rs
+++ b/blog_os/tests/should_panic.rs
@@ -10,7 +10,13 @@ pub extern "C" fn _start() -> ! {
     serial_println!("should_panic::invalid_cluster...");
     let disk = MemoryDisk::new();
     let mut fs = Fat32::new(disk).expect("fs");
-    let entry = DirectoryEntry { name: *b"BADFILEBIN  ", attr: 0x20, first_cluster: 99, size: 1 };
+    // invalid file with cluster 99 to trigger panic
+    let entry = DirectoryEntry {
+        name: *b"BADFILE BIN", // 8.3 filename padded to 11 bytes
+        attr: 0x20,
+        first_cluster: 99,
+        size: 1,
+    };
     let _ = fs.open_file(&entry);
     serial_println!("[test did not panic]");
     exit_qemu(QemuExitCode::Failed);


### PR DESCRIPTION
## Summary
- correct FAT32 directory entry in `should_panic` test

## Testing
- `cargo build --target x86_64-unknown-linux-gnu` *(fails: `#![feature]` may not be used on stable channel)*

------
https://chatgpt.com/codex/tasks/task_b_68427d7d27e48323b18ba73045d6b932