### PR TITLE
Fix tests harness setup and allocator skeleton

### DIFF
--- a/blog_os/src/allocator.rs
+++ b/blog_os/src/allocator.rs
@@ -119,6 +119,14 @@ impl SimpleAllocator {
             ],
         }
     }
+
+    /// Initialise explicitement la zone de heap utilisée par l'allocateur.
+    ///
+    /// Cette implémentation conserve un heap statique interne, les paramètres
+    /// sont donc simplement ignorés pour compatibilité.
+    pub unsafe fn init(&self, _heap_start: usize, _heap_size: usize) {
+        // Le heap est statique, aucune action n’est nécessaire ici.
+    }
 }
 
 unsafe impl GlobalAlloc for SimpleAllocator {

--- a/blog_os/src/lib.rs
+++ b/blog_os/src/lib.rs
@@ -134,18 +134,4 @@ pub fn fat32_checks<D: fat32::BlockDevice>(mut fat: fat32::Fat32<D>) {
     );
 }
 
-#[cfg(test)]
-pub fn test_runner(tests: &[&dyn Fn()]) {
-    for test in tests {
-        test();
-    }
-}
-
-#[cfg(test)]
-#[no_mangle]
-pub extern "C" fn test_main() {
-    let tests: &[&dyn Fn()] = &[];
-    test_runner(tests);
-}
-
 


### PR DESCRIPTION
## Summary
- avoid duplicate `test_main` by relying on the harness-generated one
- expose a no-op `init` method in the slab allocator

## Testing
- `cargo test --target x86_64-blog_os.json` *(fails: target not installed)*
- `cargo bootimage` *(fails: `bootimage` not installed)*

------
https://chatgpt.com/codex/tasks/task_b_684288b496408323bbe077ccfa667afe