### PR TITLE
Fix allocator and FAT32 methods

### DIFF
--- a/blog_os/src/allocator.rs
+++ b/blog_os/src/allocator.rs
@@ -4,8 +4,6 @@
 //! optimisé pour l'allocation fréquente de petits objets. Chaque slab gère
 //! des blocs de même taille, améliorant la rapidité et réduisant la fragmentation.
 
-#![cfg(feature = "alloc")]
-
 extern crate alloc;
 
 use core::alloc::{GlobalAlloc, Layout};
@@ -173,7 +171,7 @@ unsafe impl GlobalAlloc for SimpleAllocator {
 ///
 /// Panique en détaillant la `layout` requise.
 /// Désactivé si la feature `oom_integration` est activée.
-#[cfg(all(feature = "alloc", not(feature = "oom_integration")))]
+#[cfg(not(feature = "oom_integration"))]
 #[alloc_error_handler]
 fn on_oom(layout: Layout) -> ! {
     panic!("Out of memory: {:?}", layout);

--- a/blog_os/src/fat32.rs
+++ b/blog_os/src/fat32.rs
@@ -3,12 +3,9 @@ pub trait BlockDevice {
     fn write_sector(&mut self, lba: u32, buf: &[u8; 512]);
 }
 
-#[cfg(feature = "alloc")]
 extern crate alloc;
 
-#[cfg(feature = "alloc")]
 use alloc::{string::String, vec::Vec};
-#[cfg(feature = "alloc")]
 use alloc::{format, vec};
 
 #[derive(Debug, Clone, Copy)]
@@ -21,7 +18,7 @@ pub struct BootSector {
     pub root_cluster: u32,
 }
 
-#[cfg_attr(feature = "alloc", derive(Debug, Clone))]
+#[derive(Debug, Clone)]
 pub struct DirectoryEntry {
     pub name: [u8; 11],
     pub attr: u8,
@@ -29,7 +26,6 @@ pub struct DirectoryEntry {
     pub size: u32,
 }
 
-#[cfg(feature = "alloc")]
 impl DirectoryEntry {
     pub fn filename(&self) -> String {
         let name = core::str::from_utf8(&self.name[..8]).unwrap().trim_end();
@@ -109,7 +105,6 @@ impl<D: BlockDevice> Fat32<D> {
         buf[..512].copy_from_slice(&tmp);
     }
 
-    #[cfg(feature = "alloc")]
     fn read_cluster_chain(&mut self, start: u32) -> Result<Vec<u8>, ()> {
         if start < 2 {
             panic!("invalid cluster {}", start);
@@ -133,7 +128,6 @@ impl<D: BlockDevice> Fat32<D> {
         Ok(data)
     }
 
-    #[cfg(feature = "alloc")]
     pub fn read_root_directory(&mut self) -> Result<Vec<DirectoryEntry>, ()> {
         let data = self.read_cluster_chain(self.boot_sector.root_cluster)?;
         let mut entries = Vec::new();
@@ -154,7 +148,6 @@ impl<D: BlockDevice> Fat32<D> {
         Ok(entries)
     }
 
-    #[cfg(feature = "alloc")]
     pub fn open_file(&mut self, entry: &DirectoryEntry) -> Result<Vec<u8>, ()> {
         let mut data = self.read_cluster_chain(entry.first_cluster)?;
         data.truncate(entry.size as usize);

--- a/blog_os/src/lib.rs
+++ b/blog_os/src/lib.rs
@@ -13,15 +13,13 @@
 #![reexport_test_harness_main = "test_main"]
 
 // On active alloc_error_handler **seulement** si on n'est PAS en oom_integration.
-#![cfg_attr(all(feature = "alloc", not(feature = "oom_integration")), feature(alloc_error_handler))]
+#![cfg_attr(not(feature = "oom_integration"), feature(alloc_error_handler))]
 
-#[cfg(feature = "alloc")]
 extern crate alloc;
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(feature = "alloc")]
     #[allow(unused_imports)]
     use alloc::{boxed::Box, vec::Vec};
 
@@ -32,14 +30,11 @@ use core::panic::PanicInfo;
 
 pub mod serial;
 pub mod vga_buffer;
-#[cfg(feature = "alloc")]
 pub mod allocator;
 pub mod fat32;
 
-#[cfg(feature = "alloc")]
 use crate::allocator::SimpleAllocator;
 
-#[cfg(feature = "alloc")]
 #[global_allocator]
 static ALLOCATOR: SimpleAllocator = SimpleAllocator::new();
 


### PR DESCRIPTION
## Summary
- make the slab allocator unconditional
- remove `cfg(feature = "alloc")` so tests build without features
- keep the OOM handler only when `oom_integration` feature is off

## Testing
- `cargo bootimage` *(fails: can't find crate for `core`)*
- `cargo test --target x86_64-blog_os.json` *(fails: can't find crate for `core`)*
- `qemu-system-x86_64 -drive format=raw,file=target/x86_64-blog_os/debug/bootimage-blog_os.bin` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_684325af6b348323b0ed4ece261be375