### PR TITLE
Fix custom test harness for OOM and panic tests

### DIFF
--- a/blog_os/tests/oom.rs
+++ b/blog_os/tests/oom.rs
@@ -1,5 +1,8 @@
 #![no_std]
 #![no_main]
+#![feature(custom_test_frameworks)]
+#![test_runner(blog_os::test_runner)]
+#![reexport_test_harness_main = "test_main"]
 #![feature(alloc_error_handler)]
 
 extern crate alloc;
@@ -22,6 +25,12 @@ fn panic(_: &PanicInfo) -> ! {
 
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
+    test_main();
+    loop {}
+}
+
+#[test_case]
+fn test_oom() {
     let _buf: Box<[u8; 1024]> = Box::new([0; 1024]);
     exit_qemu(QemuExitCode::Failed);
 }

--- a/blog_os/tests/should_panic.rs
+++ b/blog_os/tests/should_panic.rs
@@ -12,6 +12,12 @@ use blog_os::fat32::{Fat32, MemoryDisk, DirectoryEntry};
 
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
+    test_main();
+    loop {}
+}
+
+#[test_case]
+fn invalid_cluster_panics() {
     serial_println!("should_panic::invalid_cluster...");
     let disk = MemoryDisk::new();
     let mut fs = Fat32::new(disk).expect("fs");


### PR DESCRIPTION
## Summary
- align test files with the expected custom test harness boilerplate
- add test functions so `_start` only calls `test_main`

## Testing
- `cargo test --quiet` *(fails: can't find crate for `core`)*

------
https://chatgpt.com/codex/tasks/task_b_6843294176d483239af190b057cc4373