### PR TITLE
Simplify test entrypoints

### DIFF
--- a/blog_os/src/lib.rs
+++ b/blog_os/src/lib.rs
@@ -38,33 +38,6 @@ use crate::allocator::SimpleAllocator;
 #[global_allocator]
 static ALLOCATOR: SimpleAllocator = SimpleAllocator::new();
 
-/// Trait étendant les tests pour permettre l'affichage de leur nom.
-pub trait Testable {
-    fn run(&self);
-}
-
-impl<T> Testable for T where T: Fn() {
-    fn run(&self) {
-        serial_print!("{}...\t", core::any::type_name::<T>());
-        self();
-        serial_println!("[ok]");
-    }
-}
-
-
-/// Exécute tous les tests fournis et renvoie le code de sortie à QEMU.
-///
-/// # Panics
-/// Panique si un test échoue.
-#[cfg(not(test))]
-pub fn test_runner(tests: &[&dyn Testable]) {
-    serial_println!("Running {} tests", tests.len());
-    for test in tests {
-        test.run();
-    }
-    exit_qemu(QemuExitCode::Success);
-}
-
 #[cfg(test)]
 pub fn test_runner(tests: &[&dyn Fn()]) {
     for test in tests {


### PR DESCRIPTION
## Summary
- remove the unused non-test `test_runner` and helper trait
- keep a single `test_main` and `test_runner` definition
- ensure test binaries use the exported `test_main`

## Testing
- `cargo test --no-run` *(fails: can't find crate for `core`)*

------
https://chatgpt.com/codex/tasks/task_b_6844398634f483239a976aae121ec8f7