### PR TITLE
Fix test runner exposure and unify integration headers

### DIFF
--- a/blog_os/src/lib.rs
+++ b/blog_os/src/lib.rs
@@ -37,7 +37,7 @@ use crate::allocator::SimpleAllocator;
 #[global_allocator]
 static ALLOCATOR: SimpleAllocator = SimpleAllocator::new();
 
-#[cfg(test)]
+/// Test runner global (doit être visible des tests d’intégration)
 pub fn test_runner(tests: &[&dyn Fn()]) {
     for test in tests {
         test();

--- a/blog_os/src/main.rs
+++ b/blog_os/src/main.rs
@@ -1,8 +1,7 @@
+#![cfg(not(test))]
 #![no_std]
 #![no_main]
 #![feature(custom_test_frameworks)]
-#![test_runner(blog_os::test_runner)]
-#![reexport_test_harness_main = "test_main"]
 
 use blog_os::println;
 use blog_os::fat32::{Fat32, MemoryDisk};

--- a/blog_os/tests/basic_boot.rs
+++ b/blog_os/tests/basic_boot.rs
@@ -5,14 +5,11 @@
 #![reexport_test_harness_main = "test_main"]
 
 extern crate blog_os;
-
 use core::panic::PanicInfo;
-use blog_os::println;
 
-#[no_mangle] // don't mangle the name of this function
+#[no_mangle]
 pub extern "C" fn _start() -> ! {
     test_main();
-
     loop {}
 }
 
@@ -20,6 +17,10 @@ pub extern "C" fn _start() -> ! {
 fn panic(info: &PanicInfo) -> ! {
     blog_os::test_panic_handler(info)
 }
+
+use blog_os::println;
+extern crate alloc;
+use alloc::boxed::Box;
 
 #[test_case]
 fn test_println() {

--- a/blog_os/tests/fat32.rs
+++ b/blog_os/tests/fat32.rs
@@ -4,13 +4,8 @@
 #![test_runner(blog_os::test_runner)]
 #![reexport_test_harness_main = "test_main"]
 
-extern crate alloc;
 extern crate blog_os;
-
 use core::panic::PanicInfo;
-use blog_os::fat32::{Fat32, MemoryDisk};
-use blog_os::{test_panic_handler};
-use alloc::vec::Vec;
 
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
@@ -20,8 +15,10 @@ pub extern "C" fn _start() -> ! {
 
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
-    test_panic_handler(info)
+    blog_os::test_panic_handler(info)
 }
+
+use blog_os::fat32::{Fat32, MemoryDisk};
 
 #[test_case]
 fn read_root_dir_test() {

--- a/blog_os/tests/should_panic.rs
+++ b/blog_os/tests/should_panic.rs
@@ -5,16 +5,21 @@
 #![reexport_test_harness_main = "test_main"]
 
 extern crate blog_os;
-
 use core::panic::PanicInfo;
-use blog_os::{exit_qemu, serial_println, QemuExitCode};
-use blog_os::fat32::{Fat32, MemoryDisk, DirectoryEntry};
 
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
     test_main();
     loop {}
 }
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    blog_os::test_panic_handler(info)
+}
+
+use blog_os::{exit_qemu, serial_println, QemuExitCode};
+use blog_os::fat32::{Fat32, MemoryDisk, DirectoryEntry};
 
 #[test_case]
 fn invalid_cluster_panics() {
@@ -31,11 +36,4 @@ fn invalid_cluster_panics() {
     let _ = fs.open_file(&entry);
     serial_println!("[test did not panic]");
     exit_qemu(QemuExitCode::Failed);
-}
-
-#[panic_handler]
-fn panic(_info: &PanicInfo) -> ! {
-    serial_println!("[ok]");
-    exit_qemu(QemuExitCode::Success);
-   
 }


### PR DESCRIPTION
## Summary
- expose a single `test_runner` and `test_main` in `src/lib.rs`
- avoid compiling `main.rs` when running `cargo test`
- standardize integration test headers

## Testing
- `cargo clean`
- `cargo test --target x86_64-blog_os.json --no-run` *(fails: target not installed)*
- `cargo bootimage` *(fails: `cargo-bootimage` not installed)*
- `qemu-system-x86_64 -drive format=raw,file=target/x86_64-blog_os/debug/bootimage-blog_os.bin` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68444c0c850c83239c69901d4446d1fd