### PR TITLE
Fix test runner visibility

### DIFF
--- a/blog_os/src/lib.rs
+++ b/blog_os/src/lib.rs
@@ -38,14 +38,12 @@ use crate::allocator::SimpleAllocator;
 static ALLOCATOR: SimpleAllocator = SimpleAllocator::new();
 
 /// Test runner global (doit être visible des tests d’intégration)
-#[cfg(test)]
 pub fn test_runner(tests: &[&dyn Fn()]) {
     for test in tests {
         test();
     }
 }
 
-#[cfg(test)]
 #[no_mangle]
 pub extern "C" fn test_main() {
     let tests: &[&dyn Fn()] = &[];


### PR DESCRIPTION
## Summary
- expose `test_runner` and `test_main` so integration tests can link

## Testing
- `cargo test --target x86_64-blog_os.json --no-run` *(fails: can't find crate for `core`)*

------
https://chatgpt.com/codex/tasks/task_b_684465d6ac788323afb8bbfdb792844c