### PR TITLE
Fix test setup for no_std kernel

### DIFF
--- a/blog_os/Cargo.toml
+++ b/blog_os/Cargo.toml
@@ -3,6 +3,16 @@ name = "blog_os"
 version = "0.1.0"
 edition = "2018"
 
+[lib]
+path = "src/lib.rs"
+bench = false
+
+[[bin]]
+name = "blog_os"
+path = "src/main.rs"
+test  = false
+bench = false
+
 [[test]]
 name = "should_panic"
 harness = false

--- a/blog_os/tests/basic_boot.rs
+++ b/blog_os/tests/basic_boot.rs
@@ -2,14 +2,13 @@
 #![no_main]
 #![feature(custom_test_frameworks)]
 #![test_runner(blog_os::test_runner)]
-#![reexport_test_harness_main = "test_main"]
 
 extern crate blog_os;
 use core::panic::PanicInfo;
 
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
-    test_main();
+    blog_os::test_main();
     loop {}
 }
 

--- a/blog_os/tests/fat32.rs
+++ b/blog_os/tests/fat32.rs
@@ -2,14 +2,13 @@
 #![no_main]
 #![feature(custom_test_frameworks)]
 #![test_runner(blog_os::test_runner)]
-#![reexport_test_harness_main = "test_main"]
 
 extern crate blog_os;
 use core::panic::PanicInfo;
 
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
-    test_main();
+    blog_os::test_main();
     loop {}
 }
 

--- a/blog_os/tests/oom.rs
+++ b/blog_os/tests/oom.rs
@@ -2,14 +2,13 @@
 #![no_main]
 #![feature(custom_test_frameworks)]
 #![test_runner(blog_os::test_runner)]
-#![reexport_test_harness_main = "test_main"]
 
 extern crate blog_os;
 use core::panic::PanicInfo;
 
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
-    test_main();
+    blog_os::test_main();
     loop {}
 }
 

--- a/blog_os/tests/should_panic.rs
+++ b/blog_os/tests/should_panic.rs
@@ -2,14 +2,13 @@
 #![no_main]
 #![feature(custom_test_frameworks)]
 #![test_runner(blog_os::test_runner)]
-#![reexport_test_harness_main = "test_main"]
 
 extern crate blog_os;
 use core::panic::PanicInfo;
 
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
-    test_main();
+    blog_os::test_main();
     loop {}
 }
 


### PR DESCRIPTION
## Summary
- ensure the library and binary definitions don't turn into test crates
- allow integration tests to pick up the kernel test runner

## Testing
- `cargo test --no-run` *(fails: can't find crate `core` because target `x86_64-blog_os` is missing)*

------
https://chatgpt.com/codex/tasks/task_b_684467ec9cd48323b5c25fca24d5adef