### PR TITLE
Remove unused imports from integration tests

### DIFF
--- a/blog_os/tests/basic_boot.rs
+++ b/blog_os/tests/basic_boot.rs
@@ -17,18 +17,17 @@ fn panic(info: &PanicInfo) -> ! {
     blog_os::test_panic_handler(info)
 }
 
-use blog_os::println;
+#[cfg(feature = "alloc")]
 extern crate alloc;
-use alloc::boxed::Box;
 
 #[test_case]
 fn test_println() {
-    println!("test_println output");
+    blog_os::println!("test_println output");
 }
 
 #[cfg(feature = "alloc")]
 #[test_case]
 fn basic_allocator_test() {
-    let value = Box::new(123_u32);
+    let value = alloc::boxed::Box::new(123_u32);
     assert_eq!(*value, 123);
 }

--- a/blog_os/tests/fat32.rs
+++ b/blog_os/tests/fat32.rs
@@ -17,12 +17,11 @@ fn panic(info: &PanicInfo) -> ! {
     blog_os::test_panic_handler(info)
 }
 
-use blog_os::fat32::{Fat32, MemoryDisk};
 
 #[test_case]
 fn read_root_dir_test() {
-    let disk = MemoryDisk::new();
-    let mut fs = Fat32::new(disk).unwrap();
+    let disk = blog_os::fat32::MemoryDisk::new();
+    let mut fs = blog_os::fat32::Fat32::new(disk).unwrap();
     let entries = fs.read_root_directory().unwrap();
     assert_eq!(entries.len(), 1);
     assert_eq!(entries[0].filename(), "HELLO.TXT");
@@ -30,8 +29,8 @@ fn read_root_dir_test() {
 
 #[test_case]
 fn read_file_test() {
-    let disk = MemoryDisk::new();
-    let mut fs = Fat32::new(disk).unwrap();
+    let disk = blog_os::fat32::MemoryDisk::new();
+    let mut fs = blog_os::fat32::Fat32::new(disk).unwrap();
     let entries = fs.read_root_directory().unwrap();
     let data = fs.open_file(&entries[0]).unwrap();
     assert_eq!(core::str::from_utf8(&data).unwrap(), "Hello");

--- a/blog_os/tests/oom.rs
+++ b/blog_os/tests/oom.rs
@@ -18,17 +18,15 @@ fn panic(info: &PanicInfo) -> ! {
 }
 
 extern crate alloc;
-use alloc::boxed::Box;
-use blog_os::{exit_qemu, QemuExitCode};
 
 #[cfg(feature = "oom_integration")]
 #[alloc_error_handler]
 fn on_oom(_layout: alloc::alloc::Layout) -> ! {
-    exit_qemu(QemuExitCode::Success);
+    blog_os::exit_qemu(blog_os::QemuExitCode::Success);
 }
 
 #[test_case]
 fn test_oom() {
-    let _buf: Box<[u8; 1024]> = Box::new([0; 1024]);
-    exit_qemu(QemuExitCode::Failed);
+    let _buf: alloc::boxed::Box<[u8; 1024]> = alloc::boxed::Box::new([0; 1024]);
+    blog_os::exit_qemu(blog_os::QemuExitCode::Failed);
 }

--- a/blog_os/tests/should_panic.rs
+++ b/blog_os/tests/should_panic.rs
@@ -17,22 +17,20 @@ fn panic(info: &PanicInfo) -> ! {
     blog_os::test_panic_handler(info)
 }
 
-use blog_os::{exit_qemu, serial_println, QemuExitCode};
-use blog_os::fat32::{Fat32, MemoryDisk, DirectoryEntry};
 
 #[test_case]
 fn invalid_cluster_panics() {
-    serial_println!("should_panic::invalid_cluster...");
-    let disk = MemoryDisk::new();
-    let mut fs = Fat32::new(disk).expect("fs");
+    blog_os::serial_println!("should_panic::invalid_cluster...");
+    let disk = blog_os::fat32::MemoryDisk::new();
+    let mut fs = blog_os::fat32::Fat32::new(disk).expect("fs");
     // invalid file with cluster 99 to trigger panic
-    let entry = DirectoryEntry {
+    let entry = blog_os::fat32::DirectoryEntry {
         name: *b"BADFILE BIN", // 8.3 filename padded to 11 bytes
         attr: 0x20,
         first_cluster: 99,
         size: 1,
     };
     let _ = fs.open_file(&entry);
-    serial_println!("[test did not panic]");
-    exit_qemu(QemuExitCode::Failed);
+    blog_os::serial_println!("[test did not panic]");
+    blog_os::exit_qemu(blog_os::QemuExitCode::Failed);
 }


### PR DESCRIPTION
## Summary
- clean up unused imports in `blog_os` integration tests

## Testing
- `cargo clippy --target x86_64-blog_os.json -- -D warnings` *(fails: cargo-clippy not installed)*
- `cargo test --target x86_64-blog_os.json --no-run` *(fails: can't find crate for `core`)*

------
https://chatgpt.com/codex/tasks/task_b_68446e456f888323beeda06289e1ca0b