### PR TITLE
Fix clippy warnings

### DIFF
--- a/blog_os/src/lib.rs
+++ b/blog_os/src/lib.rs
@@ -68,7 +68,9 @@ pub fn exit_qemu(exit_code: QemuExitCode) -> ! {
         let mut port = Port::new(0xf4);
         port.write(exit_code as u32);
     }
-    loop {}
+    loop {
+        core::hint::spin_loop();
+    }
 }
 
 /// Code de sortie utilisable pour QEMU.
@@ -91,7 +93,9 @@ pub enum QemuExitCode {
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
     test_main();
-    loop {}
+    loop {
+        core::hint::spin_loop();
+    }
 }
 /// Gestionnaire de panique en mode test, renvoie un code d'échec.
 #[cfg(test)]

--- a/blog_os/src/main.rs
+++ b/blog_os/src/main.rs
@@ -24,7 +24,9 @@ pub extern "C" fn _start() -> ! {
     #[cfg(test)]
     test_main();
 
-    loop {}
+    loop {
+        core::hint::spin_loop();
+    }
 }
 
 /// This function is called on panic.
@@ -32,7 +34,9 @@ pub extern "C" fn _start() -> ! {
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
     println!("{}", info);
-    loop {}
+    loop {
+        core::hint::spin_loop();
+    }
 }
 
 #[cfg(test)]

--- a/blog_os/tests/basic_boot.rs
+++ b/blog_os/tests/basic_boot.rs
@@ -9,7 +9,9 @@ use core::panic::PanicInfo;
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
     blog_os::test_main();
-    loop {}
+    loop {
+        core::hint::spin_loop();
+    }
 }
 
 #[panic_handler]

--- a/blog_os/tests/fat32.rs
+++ b/blog_os/tests/fat32.rs
@@ -9,7 +9,9 @@ use core::panic::PanicInfo;
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
     blog_os::test_main();
-    loop {}
+    loop {
+        core::hint::spin_loop();
+    }
 }
 
 #[panic_handler]

--- a/blog_os/tests/oom.rs
+++ b/blog_os/tests/oom.rs
@@ -9,7 +9,9 @@ use core::panic::PanicInfo;
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
     blog_os::test_main();
-    loop {}
+    loop {
+        core::hint::spin_loop();
+    }
 }
 
 #[panic_handler]

--- a/blog_os/tests/should_panic.rs
+++ b/blog_os/tests/should_panic.rs
@@ -9,7 +9,9 @@ use core::panic::PanicInfo;
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
     blog_os::test_main();
-    loop {}
+    loop {
+        core::hint::spin_loop();
+    }
 }
 
 #[panic_handler]


### PR DESCRIPTION
## Summary
- apply `unwrap_or_default`
- implement `Default` for `SimpleAllocator` and `MemoryDisk`
- document `unsafe fn init`
- define a `FatError` enum and update FAT32 methods
- use `core::hint::spin_loop()` for infinite loops
- adjust test files

## Testing
- `cargo clippy --target x86_64-blog_os.json -- -D warnings` *(fails: 'cargo-clippy' not installed)*
- `cargo test --target x86_64-blog_os.json --no-run` *(fails: can't find target)*
- `cargo bootimage` *(fails: no such command `bootimage`)*

------
https://chatgpt.com/codex/tasks/task_b_68447073061c832390441a990e3dca83